### PR TITLE
IconMoon Aliases

### DIFF
--- a/lib/create-icon-set-from-icomoon.js
+++ b/lib/create-icon-set-from-icomoon.js
@@ -7,7 +7,9 @@ export default function createIconSetFromIcoMoon(
 ) {
   const glyphMap = {};
   config.icons.forEach(icon => {
-    glyphMap[icon.properties.name] = icon.properties.code;
+    icon.properties.name.split(/\s*,\s*/g).forEach(name => {
+      glyphMap[name] = icon.properties.code;
+    });
   });
 
   const fontFamily =


### PR DESCRIPTION
The IconMoon may have few names for the same icon. Like "spinner, loader, wait"

`...
"properties": {
        "order": 174,
        "id": 27,
        "name": "spinner, loader, wait",
        "prevSize": 32,
        "code": 59648
      }
...
`